### PR TITLE
Fix severity filter unit test

### DIFF
--- a/src/test/java/io/github/finoid/maven/plugins/codequality/step/StepResultsUnitTest.java
+++ b/src/test/java/io/github/finoid/maven/plugins/codequality/step/StepResultsUnitTest.java
@@ -47,7 +47,7 @@ class StepResultsUnitTest extends UnitTest {
     void givenNonPermissiveViolation_whenGetNonPermissiveViolationsAndHigherSeverity_thenReturnsNoViolation() {
         var nonPermissiveProjectStepResults = ProjectStepResultsFaker.projectStepResults()
             .withStepResult(StepResultFaker.stepResultFaker()
-                .withIsPermissive(true)
+                .withIsPermissive(false)
                 .withViolation(ViolationFaker.violation()
                     .withSeverity(Severity.INFO)
                     .create())


### PR DESCRIPTION
## Summary
- update `givenNonPermissiveViolation_whenGetNonPermissiveViolationsAndHigherSeverity_thenReturnsNoViolation`
  to actually create a non-permissive violation

## Testing
- `./mvnw -q test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684c4c50152483288836184d674f65d8