### PR TITLE
Update Javadoc for nonBlank

### DIFF
--- a/src/main/java/io/github/finoid/maven/plugins/codequality/util/Precondition.java
+++ b/src/main/java/io/github/finoid/maven/plugins/codequality/util/Precondition.java
@@ -63,7 +63,7 @@ public final class Precondition {
 
     /**
      * Checks if the provided subject is not blank. If it is blank, a IllegalArgumentException is thrown with the message
-     * provided by the messageSupplier.
+     * provided by the message.
      *
      * @param subject the subject to check for blank
      * @param message the exception message.


### PR DESCRIPTION
## Summary
- fix javadoc wording for `nonBlank`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684c4c143c448328bf524d7178ee532f